### PR TITLE
Reduce file size

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,18 +27,18 @@
   ],
   "devDependencies": {
     "@akashic/akashic-engine": "~2.0.0",
+    "@types/uglify-js": "~2.6.29",
+    "browserify": "^13.0.0",
     "del": "~1.1.1",
     "gulp": "~3.9.1",
+    "gulp-expect-file": "0.0.7",
     "gulp-istanbul": "~0.10.4",
     "gulp-jasmine": "~2.3.0",
+    "gulp-rename": "^1.2.0",
     "gulp-shell": "~0.5.2",
     "gulp-tslint": "~4.3.5",
-    "gulp-expect-file": "0.0.7",
     "gulp-uglify": "~2.0.0",
-    "gulp-rename": "^1.2.0",
     "gulp-util": "^3.0.7",
-    "browserify": "^13.0.0",
-    "vinyl-source-stream": "^1.1.0",
     "jasmine": "~2.1.1",
     "jasmine-reporters": "~2.0.4",
     "jasmine-terminal-reporter": "~0.9.1",
@@ -47,14 +47,16 @@
     "mock-fs": "3.12.1",
     "tslint": "~3.7.4",
     "typescript": "~2.1.6",
-    "typings": "1.0.4"
+    "typings": "1.0.4",
+    "vinyl-source-stream": "^1.1.0"
   },
   "typings": "lib/index.d.ts",
   "dependencies": {
     "@akashic/akashic-cli-commons": "~0.2.2",
     "commander": "2.8.1",
     "ect": "^0.5.9",
-    "fs-extra": "3.0.1"
+    "fs-extra": "3.0.1",
+    "uglify-js": "2.6.1"
   },
   "optionalDependencies": {
     "@akashic/game-driver": "~1.0.0",

--- a/src/app/cli.ts
+++ b/src/app/cli.ts
@@ -11,6 +11,7 @@ interface CommandParameterObject {
 	output?: string;
 	exclude?: string[];
 	strip?: boolean;
+	minify?: boolean;
 	bundle?: boolean;
 	magnify?: boolean;
 }
@@ -25,6 +26,7 @@ function cli(param: CommandParameterObject): void {
 		exclude: param.exclude,
 		logger: logger,
 		strip: param.strip,
+		minify: param.minify,
 		bundle: param.bundle,
 		magnify: param.magnify
 	};
@@ -48,6 +50,7 @@ commander
 	.option("-q, --quiet", "Suppress output")
 	.option("-o, --output <fileName>", "Name of output file or directory")
 	.option("-s, --strip", "output stripped fileset")
+	.option("-M, --minify", "minify JavaScript files")
 	.option("-b, --bundle", "bundle assets and scripts in index.html (to reduce the number of files)")
 	.option("-m, --magnify", "fit game area to outer element size")
 	.option("-e, --exclude [fileNames]", "Name of exclude file", (fileNames: string, list: string[]) => {

--- a/src/app/convertBundle.ts
+++ b/src/app/convertBundle.ts
@@ -120,6 +120,6 @@ function writeCommonFiles(
 	(<any>(fsx.copySync))(
 		path.resolve(__dirname, "..", templatePath),
 		outputPath,
-		{ filter: (src: string, dest: string) => (dest !== jsDir && dest !== cssDir) }
+		{ filter: (src: string, dest: string): boolean => (dest !== jsDir && dest !== cssDir) }
 	);
 }

--- a/src/app/convertBundle.ts
+++ b/src/app/convertBundle.ts
@@ -10,6 +10,7 @@ import {
 	encodeText,
 	wrap,
 	getDefaultBundleScripts,
+	getDefaultBundleStyle,
 	resolveOutputPath,
 	extractAssetDefinitions
 } from "./convertUtil";
@@ -98,6 +99,7 @@ function writeEct(
 		assets: innerHTMLAssetArray,
 		preloadScripts: scripts.preloadScripts,
 		postloadScripts: scripts.postloadScripts,
+		css: getDefaultBundleStyle(templatePath),
 		magnify: !!options.magnify
 	});
 	fs.writeFileSync(path.resolve(outputPath, "./index.html"), html);
@@ -112,13 +114,12 @@ function writeCommonFiles(
 		copyAssetFiles(outputPath, options);
 	}
 
-	const filterFunc = (src: string, dest: string) => {
-		return  !(dest === path.resolve(outputPath, "js"));
-	};
-
+	const jsDir = path.resolve(outputPath, "js");
+	const cssDir = path.resolve(outputPath, "css");
 	// fs-extraのd.tsではCopyFilterにdest引数が定義されていないため、anyにキャストする
 	(<any>(fsx.copySync))(
 		path.resolve(__dirname, "..", templatePath),
 		outputPath,
-		{ filter: filterFunc});
+		{ filter: (src: string, dest: string) => (dest !== jsDir && dest !== cssDir) }
+	);
 }

--- a/src/app/convertBundle.ts
+++ b/src/app/convertBundle.ts
@@ -3,8 +3,16 @@ import * as path from "path";
 import * as cmn from "@akashic/akashic-cli-commons";
 import * as fsx from "fs-extra";
 import * as ect from "ect";
-import { ConvertTemplateParameterObject, copyAssetFilesStrip, copyAssetFiles, wrap,
-		getDefaultBundleScripts, resolveOutputPath, extractAssetDefinitions  } from "./convertUtil";
+import {
+	ConvertTemplateParameterObject,
+	copyAssetFilesStrip,
+	copyAssetFiles,
+	encodeText,
+	wrap,
+	getDefaultBundleScripts,
+	resolveOutputPath,
+	extractAssetDefinitions
+} from "./convertUtil";
 
 interface InnerHTMLAssetData {
 	name: string;
@@ -25,7 +33,7 @@ export async function promiseConvertBundle(options: ConvertTemplateParameterObje
 	innerHTMLAssetArray.push({
 		name: "game.json",
 		type: "text",
-		code: encodeURIComponent(JSON.stringify(conf._content, null, "\t"))
+		code: encodeText(JSON.stringify(conf._content, null, "\t"))
 	});
 
 	var innerHTMLAssetNames = extractAssetDefinitions(conf, "script").concat(extractAssetDefinitions(conf, "text"));
@@ -48,7 +56,7 @@ export async function promiseConvertBundle(options: ConvertTemplateParameterObje
 			templatePath = "templates/template-export-html-v2";
 			break;
 		default:
-			throw Error("unknown Akashic Engine version selected");
+			throw Error("Unknown engine version: `environment[\"sandbox-runtime\"]` field in game.json should be \"1\" or \"2\".");
 	}
 
 	writeEct(innerHTMLAssetArray, outputPath, conf, options, templatePath);
@@ -62,7 +70,7 @@ function convertAssetToInnerHTMLObj(assetName: string, conf: cmn.Configuration):
 	return {
 		name: assetName,
 		type: assets[assetName].type,
-		code: (isScript ? wrap(assetString) : encodeURIComponent(assetString))
+		code: (isScript ? wrap(assetString) : encodeText(assetString))
 	};
 }
 
@@ -72,7 +80,7 @@ function convertScriptNameToInnerHTMLObj(scriptName: string): InnerHTMLAssetData
 
 	var scriptPath = path.resolve("./", scriptName);
 	if (path.extname(scriptPath) === ".json") {
-		scriptString = encodeURIComponent(scriptString);
+		scriptString = encodeText(scriptString);
 	}
 	return {
 		name: scriptName,

--- a/src/app/convertNoBundle.ts
+++ b/src/app/convertNoBundle.ts
@@ -3,8 +3,15 @@ import * as path from "path";
 import * as cmn from "@akashic/akashic-cli-commons";
 import * as fsx from "fs-extra";
 import * as ect from "ect";
-import { ConvertTemplateParameterObject, copyAssetFilesStrip, copyAssetFiles, wrap,
-	resolveOutputPath, extractAssetDefinitions } from "./convertUtil";
+import {
+	ConvertTemplateParameterObject,
+	copyAssetFilesStrip,
+	copyAssetFiles,
+	encodeText,
+	wrap,
+	resolveOutputPath,
+	extractAssetDefinitions
+} from "./convertUtil";
 
 export async function promiseConvertNoBundle(options: ConvertTemplateParameterObject): Promise<void> {
 	var content = await cmn.ConfigurationFile.read(path.join(process.cwd(), "game.json"), options.logger);
@@ -21,8 +28,7 @@ export async function promiseConvertNoBundle(options: ConvertTemplateParameterOb
 	assetPaths.push("./js/game.json.js");
 
 	var assetNames = extractAssetDefinitions(conf, "script").concat(extractAssetDefinitions(conf, "text"));
-	assetPaths = assetPaths.concat(assetNames.map((assetName: string) => {
-		return convertAssetAndOutput(assetName, conf, outputPath);
+	assetPaths = assetPaths.concat(assetNames.map((assetName: string) => { return convertAssetAndOutput(assetName, conf, outputPath);
 	}));
 
 	if (conf._content.globalScripts) {
@@ -87,7 +93,7 @@ function writeCommonFiles(outputPath: string, conf: cmn.Configuration, options: 
 			templatePath = "templates/template-export-html-v2";
 			break;
 		default:
-			throw Error("unknown Akashic Engine version selected");
+			throw Error("Unknown engine version: `environment[\"sandbox-runtime\"]` field in game.json should be \"1\" or \"2\".");
 	}
 
 	fsx.copySync(
@@ -112,5 +118,5 @@ function wrapScript(code: string, name: string): string {
 function wrapText(code: string, name: string): string {
 	var PRE_SCRIPT = "window.gLocalAssetContainer[\"" + name + "\"] = \"";
 	var POST_SCRIPT = "\"";
-	return PRE_SCRIPT + encodeURIComponent(code) + POST_SCRIPT + "\n";
+	return PRE_SCRIPT + encodeText(code) + POST_SCRIPT + "\n";
 }

--- a/src/app/convertUtil.ts
+++ b/src/app/convertUtil.ts
@@ -73,10 +73,10 @@ export function copyAssetFilesStrip(outputPath: string, assets: cmn.Assets, opti
 
 export function copyAssetFiles(outputPath: string, options: ConvertTemplateParameterObject ): void {
 	options.logger.info("copying files...");
-	const scriptPath = path.resolve(outputPath, "script");
-	const textPath = path.resolve(outputPath, "text");
+	const scriptPath = path.resolve(process.cwd(), "script");
+	const textPath = path.resolve(process.cwd(), "text");
 	const filterFunc = (src: string, dest: string) => {
-		return src.indexOf(scriptPath) === -1 && src.indexOf(textPath) === -1;
+		return path.relative(scriptPath, src)[0] === "." && path.relative(textPath, src)[0] === ".";
 	};
 	try {
 		// fs-extraのd.tsではCopyFilterにdest引数が定義されていないため、anyにキャストする

--- a/src/app/convertUtil.ts
+++ b/src/app/convertUtil.ts
@@ -115,10 +115,15 @@ export function getDefaultBundleScripts(templatePath: string, minify?: boolean):
 	};
 }
 
+export function getDefaultBundleStyle(templatePath: string): string {
+	const filepath = path.resolve(__dirname, "..", templatePath, "css", "style.css");
+	return fs.readFileSync(filepath, "utf8").replace(/\r\n|\r/g, "\n");
+}
+
 function loadScriptFile(fileName: string, templatePath: string): string {
 	try {
-		return fs.readFileSync(
-			path.resolve(__dirname, "..", templatePath, "js", fileName), "utf8").replace(/\r\n|\r/g, "\n");
+		const filepath = path.resolve(__dirname, "..", templatePath, "js", fileName);
+		return fs.readFileSync(filepath, "utf8").replace(/\r\n|\r/g, "\n");
 	} catch (e) {
 		if (e.code === "ENOENT") {
 			throw new Error(fileName + " is not found. Try re-install akashic-cli" + path.resolve(__dirname, "..", templatePath, fileName));

--- a/src/app/convertUtil.ts
+++ b/src/app/convertUtil.ts
@@ -84,6 +84,10 @@ export function copyAssetFiles(outputPath: string, options: ConvertTemplateParam
 	}
 }
 
+export function encodeText(text: string): string {
+	return text.replace(/[\u2028\u2029'"\\\b\f\n\r\t\v]/g, encodeURIComponent);
+}
+
 export function wrap(code: string): string {
 	var PRE_SCRIPT = "(function(exports, require, module, __filename, __dirname) {";
 	var POST_SCRIPT = "})(g.module.exports, g.module.require, g.module, g.filename, g.dirname);";

--- a/templates/bundle-index.ect
+++ b/templates/bundle-index.ect
@@ -39,7 +39,9 @@ if (! ("gLocalAssetContainer" in window)) {
 <% end %>
 </script>
 
-<link rel="stylesheet" type="text/css" href="css/style.css">
+<style type="text/css">
+<%- @css %>
+</style>
 
 </head>
 <body>


### PR DESCRIPTION
## このpull requestが解決する内容

- TextAsset のエスケープ方法を変更 (ファイルサイズ削減)
  - 従来 `endodeURIComponent()` でエスケープされていましたが、JSの文字列で書ける記号(`:` など)までエスケープされて(特にJSONの)ファイルサイズを悪化させていました。必要な文字のみ `encodeURIComponent()` をかけるよう改めます
  - (特に akashic-animaiton を多用するコンテンツで 100KB 弱軽くなるのを確認)
- `--minify` (`-M`) オプションを追加 (ファイルサイズ削減)
  - 指定された場合、 スクリプトアセットをuglify-jsにかけてminify
  - `--bundle` 時は index.html に組み込まれる akashic-engine.js なども対象にします
- `--bundle` オプション時、 css/style.css も index.html に取り込むように変更 (ファイル数削減)

## 破壊的な変更を含んでいるか?
なし (ただし出力ファイル内容は変化します)
