### PR TITLE
fix publishConfig

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,6 +74,6 @@
     "url": "https://github.com/akashic-games/akashic-cli-export-html.git"
   },
   "publishConfig": {
-    "@akashic:registry": "http://registry.npmjs.org/"
+    "@akashic:registry": "https://registry.npmjs.org/"
   }
 }


### PR DESCRIPTION
掲題の通りです。
https://github.com/akashic-games/akashic-cli-export-html/pull/30 の修正を `npm publish` するために https の指定を追加します。

この修正により、 https://github.com/akashic-games/akashic-cli-export-html/pull/30 の内容が publish できるようになります。