### PR TITLE
atsumaruオプションの動作修正(主にロギング処理)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## Unreleased changes
+* `--atsumaru` オプションの修正
+
 ## 0.1.36
 * `--magnify`オプションを使用してもコンテンツがRPGアツマールページでリサイズされない不具合の修正
 * `--atsumaru` オプション使用時に`--magnify`オプションも同時に使用されるように変更

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # CHANGELOG
 
 ## Unreleased changes
-* `--atsumaru` オプションの修正
+* `--atsumaru` オプション指定時、二度 lint される問題を修正
+* `--atsumaru` オプション指定時、`game.json` に `environment.niconico.supportedModes` が指定されているかのチェックを追加
+* export処理を開始したことを示す文言を表示
 
 ## 0.1.36
 * `--magnify`オプションを使用してもコンテンツがRPGアツマールページでリサイズされない不具合の修正

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## Unreleased changes
+## 0.1.37
 * `--atsumaru` オプション指定時、二度 lint される問題を修正
 * `--atsumaru` オプション指定時、`game.json` に `environment.niconico.supportedModes` が指定されているかのチェックを追加
 * export処理を開始したことを示す文言を表示

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/akashic-cli-export-html",
-  "version": "0.1.36",
+  "version": "0.1.37",
   "description": "A module to convert your Akashic game to a runnable standalone.",
   "main": "lib/index.js",
   "scripts": {

--- a/spec/exportAtsumaruSpec.js
+++ b/spec/exportAtsumaruSpec.js
@@ -48,6 +48,8 @@ describe("exportAtsumaru", function () {
 					expect(gameJson.environment.external.send).toBe("0");
 					expect(gameJson.environment["akashic-runtime"]["version"]).toMatch(/^~1\.1\.\d+$/);
 					expect(gameJson.environment["akashic-runtime"]["flavor"]).toBe(undefined);
+					expect(gameJson.environment["niconico"]["supportedModes"].length).toBe(1);
+					expect(gameJson.environment["niconico"]["supportedModes"]).toContain("single");
 				})
 				.then(done, done.fail);
 		});
@@ -65,6 +67,8 @@ describe("exportAtsumaru", function () {
 					expect(gameJson.environment.external.send).toBe("0");
 					expect(gameJson.environment["akashic-runtime"]["version"]).toMatch(/^~2\.1\.\d+$/);
 					expect(gameJson.environment["akashic-runtime"]["flavor"]).toBe("-canvas");
+					expect(gameJson.environment["niconico"]["supportedModes"].length).toBe(1);
+					expect(gameJson.environment["niconico"]["supportedModes"]).toContain("single");
 				})
 				.then(function() {
 					fsx.removeSync(outputDirPath);
@@ -85,6 +89,9 @@ describe("exportAtsumaru", function () {
 					expect(gameJson.environment.external.send).toBe("0");
 					expect(gameJson.environment["akashic-runtime"]["version"]).toBe("~1.0.9-beta");
 					expect(gameJson.environment["akashic-runtime"]["flavor"]).toBe(undefined);
+					expect(gameJson.environment["niconico"]["supportedModes"].length).toBe(2);
+					expect(gameJson.environment["niconico"]["supportedModes"]).toContain("single");
+					expect(gameJson.environment["niconico"]["supportedModes"]).toContain("ranking");
 				})
 				.then(function() {
 					fsx.removeSync(outputDirPath);

--- a/spec/fixture/sample_game_with_akashic_runtime/game.json
+++ b/spec/fixture/sample_game_with_akashic_runtime/game.json
@@ -14,6 +14,9 @@
 		"sandbox-runtime": "2",
 		"akashic-runtime": {
 			"version": "~1.0.9-beta"
+		},
+		"niconico": {
+			"supportedModes": ["single", "ranking"]
 		}
 	}
 }

--- a/src/app/cli.ts
+++ b/src/app/cli.ts
@@ -38,7 +38,8 @@ function cli(param: CommandParameterObject): void {
 		bundle: param.bundle || param.atsumaru,
 		magnify: param.magnify || param.atsumaru,
 		injects: param.injects,
-		unbundleText: !param.bundle || param.atsumaru
+		unbundleText: !param.bundle || param.atsumaru,
+		lint: !param.atsumaru
 	};
 	Promise.resolve()
 		.then(() => {

--- a/src/app/convertBundle.ts
+++ b/src/app/convertBundle.ts
@@ -43,12 +43,12 @@ export async function promiseConvertBundle(options: ConvertTemplateParameterObje
 		innerHTMLAssetNames = innerHTMLAssetNames.concat(extractAssetDefinitions(conf, "text"));
 	}
 	innerHTMLAssetArray = innerHTMLAssetArray.concat(innerHTMLAssetNames.map((assetName: string) => {
-		return convertAssetToInnerHTMLObj(assetName, options.source, conf, options.minify, errorMessages);
+		return convertAssetToInnerHTMLObj(assetName, options.source, conf, options.minify, options.lint, errorMessages);
 	}));
 
 	if (conf._content.globalScripts) {
 		innerHTMLAssetArray = innerHTMLAssetArray.concat(conf._content.globalScripts.map((scriptName: string) => {
-			return convertScriptNameToInnerHTMLObj(scriptName, options.source, options.minify, errorMessages);
+			return convertScriptNameToInnerHTMLObj(scriptName, options.source, options.minify, options.lint, errorMessages);
 		}));
 	}
 
@@ -72,11 +72,12 @@ export async function promiseConvertBundle(options: ConvertTemplateParameterObje
 }
 
 function convertAssetToInnerHTMLObj(
-	assetName: string, inputPath: string, conf: cmn.Configuration, minify?: boolean, errors?: string[]): InnerHTMLAssetData {
+	assetName: string, inputPath: string, conf: cmn.Configuration,
+	minify?: boolean, lint?: boolean, errors?: string[]): InnerHTMLAssetData {
 	var assets = conf._content.assets;
 	var isScript = assets[assetName].type === "script";
 	var assetString = fs.readFileSync(path.join(inputPath, assets[assetName].path), "utf8").replace(/\r\n|\r/g, "\n");
-	if (isScript) {
+	if (isScript && lint) {
 		errors.push.apply(errors, validateEs5Code(assets[assetName].path, assetString));
 	}
 	return {
@@ -87,7 +88,8 @@ function convertAssetToInnerHTMLObj(
 }
 
 function convertScriptNameToInnerHTMLObj(
-	scriptName: string, inputPath: string, minify?: boolean, errors?: string[]): InnerHTMLAssetData {
+	scriptName: string, inputPath: string,
+	minify?: boolean, lint?: boolean, errors?: string[]): InnerHTMLAssetData {
 	var scriptString = fs.readFileSync(path.join(inputPath, scriptName), "utf8").replace(/\r\n|\r/g, "\n");
 	var isScript = /\.js$/i.test(scriptName);
 
@@ -95,7 +97,7 @@ function convertScriptNameToInnerHTMLObj(
 	if (path.extname(scriptPath) === ".json") {
 		scriptString = encodeText(scriptString);
 	}
-	if (isScript) {
+	if (isScript && lint) {
 		errors.push.apply(errors, validateEs5Code(scriptName, scriptString));
 	}
 	return {

--- a/src/app/convertNoBundle.ts
+++ b/src/app/convertNoBundle.ts
@@ -33,11 +33,11 @@ export async function promiseConvertNoBundle(options: ConvertTemplateParameterOb
 	var errorMessages: string[] = [];
 	assetPaths = assetPaths.concat(
 		assetNames.map((assetName: string) => {
-			return convertAssetAndOutput(assetName, conf, options.source, options.output, options.minify, errorMessages);
+			return convertAssetAndOutput(assetName, conf, options.source, options.output, options.minify, options.lint, errorMessages);
 		}));
 	if (conf._content.globalScripts) {
 		assetPaths = assetPaths.concat(conf._content.globalScripts.map((scriptName: string) => {
-			return convertGlobalScriptAndOutput(scriptName, options.source, options.output, options.minify, errorMessages);
+			return convertGlobalScriptAndOutput(scriptName, options.source, options.output, options.minify, options.lint, errorMessages);
 		}));
 	}
 	if (errorMessages.length > 0) {
@@ -50,12 +50,13 @@ export async function promiseConvertNoBundle(options: ConvertTemplateParameterOb
 
 function convertAssetAndOutput(
 	assetName: string, conf: cmn.Configuration,
-	inputPath: string, outputPath: string, minify?: boolean, errors?: string[]): string {
+	inputPath: string, outputPath: string,
+	minify?: boolean, lint?: boolean, errors?: string[]): string {
 	var assets = conf._content.assets;
 	var isScript = assets[assetName].type === "script";
 	var assetString = fs.readFileSync(path.join(inputPath, assets[assetName].path), "utf8").replace(/\r\n|\r/g, "\n");
 	var assetPath = assets[assetName].path;
-	if (isScript) {
+	if (isScript && lint) {
 		errors.push.apply(errors, validateEs5Code(assetPath, assetString)); // ES5構文に反する箇所があるかのチェック
 	}
 
@@ -69,10 +70,11 @@ function convertAssetAndOutput(
 }
 
 function convertGlobalScriptAndOutput(
-	scriptName: string, inputPath: string, outputPath: string, minify?: boolean, errors?: string[]): string {
+	scriptName: string, inputPath: string, outputPath: string,
+	minify?: boolean, lint?: boolean, errors?: string[]): string {
 	var scriptString = fs.readFileSync(path.join(inputPath, scriptName), "utf8").replace(/\r\n|\r/g, "\n");
 	var isScript = /\.js$/i.test(scriptName);
-	if (isScript) {
+	if (isScript && lint) {
 		errors.push.apply(errors, validateEs5Code(scriptName, scriptString)); // ES5構文に反する箇所があるかのチェック
 	}
 

--- a/src/app/convertUtil.ts
+++ b/src/app/convertUtil.ts
@@ -15,6 +15,7 @@ export interface ConvertTemplateParameterObject {
 	source: string;
 	cwd: string;
 	unbundleText: boolean;
+	lint: boolean;
 	injects?: string[];
 }
 

--- a/src/app/exportAtsumaru.ts
+++ b/src/app/exportAtsumaru.ts
@@ -34,7 +34,7 @@ export function promiseExportAtsumaru(param: ExportHTMLParameterObject): Promise
 			}
 			if (!gameJson.environment.niconico || !gameJson.environment.niconico.supportedModes) {
 				// モード指定がなければ、常に指定可能なモードであるsingleモードを追加する。
-				completedParam.logger.warn("Supported-modes must be specified, so \"single\" has been added");
+				completedParam.logger.warn("'environment.niconico.supportedModes', a required property  for '--atsumaru' mode, is not given in game.json. Assumed to be [\"single\"].");
 				gameJson.environment.niconico = {
 					"supportedModes": ["single"]
 				};

--- a/src/app/exportAtsumaru.ts
+++ b/src/app/exportAtsumaru.ts
@@ -34,7 +34,10 @@ export function promiseExportAtsumaru(param: ExportHTMLParameterObject): Promise
 			}
 			if (!gameJson.environment.niconico || !gameJson.environment.niconico.supportedModes) {
 				// モード指定がなければ、常に指定可能なモードであるsingleモードを追加する。
-				completedParam.logger.warn("'environment.niconico.supportedModes', a required property  for '--atsumaru' mode, is not given in game.json. Assumed to be [\"single\"].");
+				completedParam.logger.warn(
+					"'environment.niconico.supportedModes', a required property for '--atsumaru' mode," +
+					"is not given in game.json. Assumed to be [\"single\"]."
+				);
 				gameJson.environment.niconico = {
 					"supportedModes": ["single"]
 				};

--- a/src/app/exportAtsumaru.ts
+++ b/src/app/exportAtsumaru.ts
@@ -32,6 +32,13 @@ export function promiseExportAtsumaru(param: ExportHTMLParameterObject): Promise
 			if (!gameJson.environment) {
 				gameJson.environment = {};
 			}
+			if (!gameJson.environment.niconico || !gameJson.environment.niconico.supportedModes) {
+				// モード指定がなければ、常に指定可能なモードであるsingleモードを追加する。
+				completedParam.logger.warn("Supported-modes must be specified, so \"single\" has been added");
+				gameJson.environment.niconico = {
+					"supportedModes": ["single"]
+				};
+			}
 			if (!gameJson.environment.external) {
 				gameJson.environment.external = {};
 			}

--- a/src/app/exportHTML.ts
+++ b/src/app/exportHTML.ts
@@ -26,6 +26,7 @@ export function promiseExportHTML(p: ExportHTMLParameterObject): Promise<string>
 	const param = _completeExportHTMLParameterObject(p);
 	let gamepath: string;
 
+	param.logger.info("exporting content into html...");
 	if (!param.strip && param.output != null && !/^\.\./.test(path.relative(param.source, param.output))) {
 		param.logger.warn("The output path overlaps with the game directory: files will be exported into the game directory.");
 		param.logger.warn("NOTE that after this, exporting this game with --no-strip option may include the files.");
@@ -73,7 +74,8 @@ export function promiseExportHTML(p: ExportHTMLParameterObject): Promise<string>
 			source: gamepath,
 			cwd: param.cwd,
 			injects: param.injects,
-			unbundleText: param.unbundleText
+			unbundleText: param.unbundleText,
+			lint: param.lint
 		};
 		if (param.bundle) {
 			return promiseConvertBundle(convertParam);


### PR DESCRIPTION
### やったこと
* export html開始時に「exporting to html」的なメッセージを表示する
  * export html実行直後の10～20秒ほど何のメッセージも表示せずに処理が止まっているように見えることがあるため
* supportedModesがgame.jsonに書かれていない時に、警告を出してsingleを追加する対応
* atsumaruオプション時に、export-html側の構文チェックは行わないようにする対応
  * 現状だと、export-htmlとexport-zipの両方で構文チェックが行われて、構文エラーがある場合二重に警告が表示されるため