### PR TITLE
fix wrong display position on iOS Safari

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 0.1.38
+* `--magnify` オプション指定時、iOS Safariで画面位置がずれることがある問題を修正
+
 ## 0.1.37
 * `--atsumaru` オプション指定時、二度 lint される問題を修正
 * `--atsumaru` オプション指定時、`game.json` に `environment.niconico.supportedModes` が指定されているかのチェックを追加

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/akashic-cli-export-html",
-  "version": "0.1.37",
+  "version": "0.1.38",
   "description": "A module to convert your Akashic game to a runnable standalone.",
   "main": "lib/index.js",
   "scripts": {

--- a/templates/bundle-index.ect
+++ b/templates/bundle-index.ect
@@ -2,6 +2,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
 <title>game</title>
 <script>
 <% for preloadScript in @preloadScripts : %>

--- a/templates/no-bundle-index.ect
+++ b/templates/no-bundle-index.ect
@@ -2,6 +2,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
 <title>game</title>
 <script src="./js/option.js"></script>
 <script src="./js/akashic-engine.strip.js"></script>

--- a/templates/template-export-html-v1/css/style.css
+++ b/templates/template-export-html-v1/css/style.css
@@ -22,6 +22,7 @@ body {
 	touch-action: none;
 	width: 100%;
 	height: 100%;
+	position: absolute;
 }
 
 #container canvas {

--- a/templates/template-export-html-v1/css/style.css
+++ b/templates/template-export-html-v1/css/style.css
@@ -22,6 +22,8 @@ body {
 	touch-action: none;
 	width: 100%;
 	height: 100%;
+
+	/* iOS表示崩れ対策: bodyのサイズ計算からこの要素を除外 */
 	position: absolute;
 }
 

--- a/templates/template-export-html-v2/css/style.css
+++ b/templates/template-export-html-v2/css/style.css
@@ -22,6 +22,7 @@ body {
 	touch-action: none;
 	width: 100%;
 	height: 100%;
+	position: absolute;
 }
 
 #container canvas {

--- a/templates/template-export-html-v2/css/style.css
+++ b/templates/template-export-html-v2/css/style.css
@@ -22,6 +22,8 @@ body {
 	touch-action: none;
 	width: 100%;
 	height: 100%;
+
+	/* iOS表示崩れ対策: bodyのサイズ計算からこの要素を除外 */
 	position: absolute;
 }
 


### PR DESCRIPTION
## このPRが修正する内容

fixes #54.

```
iOS端末において、ゲームの解像度が端末の幅より大きい場合（iPhone8の場合 375px以上）、
resize処理の中で実行される window.innerWidth の値がゲーム解像度と同じになってしまい、
その後の中央寄せの計算で不適切な値が算出されているようです。
```

指摘のとおり iOS Safari 上でのみ、 `div#container` の幅/高さ (= game.json の width/height) が `window.innerWidth` の最小値を規定してしまうようです (`documentElement.clientWidth` も同様)。 仕様の厳密なところは追っていませんが、他ブラウザで全く再現しないところを見ると、Safari の不具合のように見えます。

この影響で `--magnify` オプションで求めるセンタリングの位置計算がずれます。仕方がないので、 `div#container` を `position: absolute` にして、外側のdimensions計算から除外させます。 `--magnify` オプションは `translate` で位置を動かすので、絶対配置でも影響はありません。

この変更後の変換結果を PRG アツマールに投稿し、以下環境で描画位置が正しくなることを確認しました。

- Windows 10 Edge
- Windows 10 Firefox
- Windows 10 Chrome
- Mac Safari
- Mac Chrome
- Mac Firefox
- iOS Safari
- Android Chrome

## 破壊的変更

- なし